### PR TITLE
Add dual deployment modes for Dioxus runner

### DIFF
--- a/ml-runner/Cargo.toml
+++ b/ml-runner/Cargo.toml
@@ -18,6 +18,7 @@ ml_backend = { package = "bento_queries", path = "../../bento_queries", optional
 pyo3-polars = "0.23.1"
 pyo3 = "0.25.1"
 serde_json = "1.0.143"
+dioxus-cli-config = { version = "0.6.0", optional = true }
 
 [features]
 default = ["web"]
@@ -28,6 +29,7 @@ server = [
     "dep:ml_backend",
     "dep:axum",
     "dep:tokio",
+    "dep:dioxus-cli-config",
 ]
 
 desktop = ["dioxus/desktop"]

--- a/ml-runner/README.md
+++ b/ml-runner/README.md
@@ -15,11 +15,37 @@ project/
 Run the following command in the root of your project to start developing with the default platform:
 
 ```bash
-dx serve --platform web
+dx serve
 ```
 
 To run for a different platform, use the `--platform platform` flag. E.g.
+
 ```bash
 dx serve --platform desktop
 ```
+
+## Deployments
+
+This crate can now be run in two different modes:
+
+* **Full stack** – launch the Dioxus front-end together with the backend:
+
+  ```bash
+  dx serve
+  ```
+
+* **Server only** – start just the backend without any UI:
+
+  ```bash
+  dx serve --platform server
+  ```
+
+  From another terminal session you can then issue commands directly against
+  the library, for example running the streaming and training pipelines:
+
+  ```bash
+  cargo run --bin server --features server train
+  ```
+
+  Replace `train` with the desired command.
 

--- a/ml-runner/src/bin/server.rs
+++ b/ml-runner/src/bin/server.rs
@@ -1,0 +1,39 @@
+#[cfg(feature = "server")]
+use ml_backend::polars_ops;
+#[cfg(feature = "server")]
+use ml_runner::{streaming_pipe, training_pipe};
+
+#[cfg(feature = "server")]
+#[tokio::main]
+async fn main() {
+    let mut args = std::env::args();
+    args.next();
+    match args.next().as_deref() {
+        Some("train") => {
+            let columns = vec!["Ret"];
+            let where_cond = polars_ops::PartEqSurr::default();
+
+            if let Err(e) = streaming_pipe(columns, "1d", where_cond, None).await {
+                eprintln!("streaming failed: {e}");
+                return;
+            }
+
+            if let Err(e) = training_pipe(
+                None,
+                "../../ml-project/py/mls_lstm_trainer.py".to_string(),
+                vec!["../../tmp_data/data.tfrecord".to_string()],
+                "train".to_string(),
+            )
+            .await
+            {
+                eprintln!("training failed: {e}");
+            }
+        }
+        _ => eprintln!("usage: server train"),
+    }
+}
+
+#[cfg(not(feature = "server"))]
+fn main() {
+    eprintln!("enable the `server` feature to run this binary");
+}

--- a/ml-runner/src/lib.rs
+++ b/ml-runner/src/lib.rs
@@ -2,6 +2,7 @@ pub mod pyexec;
 pub mod surr_queries;
 
 use dioxus::prelude::*;
+use dioxus_router::prelude::*;
 #[cfg(feature = "server")]
 use ml_backend::{polars_ops, surreal_queries};
 use polars::prelude::DataFrame;
@@ -17,17 +18,21 @@ struct Model {
 
 #[server]
 #[cfg(feature = "server")]
-async fn streaming_pipe<'a>(
-    column_set: vec<&'a str>,
+pub async fn streaming_pipe<'a>(
+    column_set: Vec<&'a str>,
     bin_size: &'a str,
     where_cond: polars_ops::PartEqSurr,
     writer_path: Option<String>,
 ) -> Result<(), ServerFnError> {
-    let db = surreal_queries::make_db?;
+    let db = surreal_queries::make_db()?;
     let df: DataFrame = surr_queries::query_feature_bin_demo(db, column_set, bin_size, where_cond)?;
+
+    let writer = writer_path
+        .unwrap_or_else(|| "../../ml-project/py/pl2tfrecord_writer.py".to_string());
+
     pyexec::write_tfrecord_from_polars(
         &df,
-        &Path::new(writer_path.unwrap_or("../../ml-project/py/pl2tfrecord_writer.py")),
+        Path::new(&writer),
         "../../tmp_data/",
         None,
         true,
@@ -36,7 +41,7 @@ async fn streaming_pipe<'a>(
 }
 
 #[server]
-async fn training_pipe(
+pub async fn training_pipe(
     reader_py_path: Option<String>,
     trainer_py_path: String,
     tfrecord_paths: Vec<String>,
@@ -44,7 +49,8 @@ async fn training_pipe(
 ) -> Result<(), ServerFnError> {
     let feature_spec = BTreeMap::new();
     let df = pyexec::load_tf_record_dataset(
-        Path::new(reader_py_path.unwrap_or("../../ml-project/py/pl2tfrecord_writer.py")),
+        Path::new(&reader_py_path
+            .unwrap_or_else(|| "../../ml-project/py/pl2tfrecord_writer.py".to_string())),
         tfrecord_paths,
         &feature_spec,
         Some("Ret"),
@@ -52,54 +58,51 @@ async fn training_pipe(
         true,
         true,
     );
-    let out = pyexec::train::run_mls_lstm_training(
-        Path::new(trainer_py_path),
+
+    let fit_kwargs = BTreeMap::new();
+    let _out = pyexec::train::run_mls_lstm_training(
+        Path::new(&trainer_py_path),
         callable_name.as_str(),
         df,
         None,
         None,
         fit_kwargs,
     );
+    Ok(())
 }
 #[component]
-pub fn app() -> Element {
-    let _search = use_signal(String::new);
-    let _selected = use_signal(|| None as Option<String>);
-    /*let models = use_future(cx, search, |search| {
-        let term = search.current().clone();
-        async move { fetch_models(&term).await.unwrap_or_default() }
-    });*/
+fn TrainingForm() -> Element {
+    let run_training = move |evt: FormEvent| {
+        evt.prevent_default();
+        spawn(async {
+            #[cfg(feature = "server")]
+            {
+                let columns = vec!["Ret"];
+                let where_cond = polars_ops::PartEqSurr::default();
+                let _ = streaming_pipe(columns, "1d", where_cond, None).await;
+                let _ = training_pipe(
+                    None,
+                    "../../ml-project/py/mls_lstm_trainer.py".to_string(),
+                    vec!["../../tmp_data/data.tfrecord".to_string()],
+                    "train".to_string(),
+                )
+                .await;
+            }
+        });
+    };
 
     rsx! {
-        /*div { class: "model-trainer",
-            input {
-                value: "{search}",
-                placeholder: "Search models...",
-                oninput: move |e| search.set(e.value.clone()),
-            }
-            ul {
-                models.value().unwrap_or(&vec![]).iter().map(|name| {
-                    let name_clone = name.clone();
-                    rsx! {
-                        li {
-                            onclick: move |_| selected.set(Some(name_clone.clone())),
-                            "{name}"
-                        }
-                    }
-                })
-            }
-            button {
-                onclick: move |_| {
-                    if let Some(name) = selected.get().clone() {
-                        tokio::spawn(async move {
-                            if let Err(e) = train_model(name).await {
-                                eprintln!("training failed: {e}");
-                            }
-                        });
-                    }
-                },
-                "Train"
-            }
-        }*/
+        form { onsubmit: run_training,
+            button { r#type: "submit", "Run Training" }
+        }
+    }
+}
+
+#[component]
+pub fn app() -> Element {
+    rsx! {
+        Router {
+            Route { to: "/", TrainingForm {} }
+        }
     }
 }

--- a/ml-runner/src/main.rs
+++ b/ml-runner/src/main.rs
@@ -1,6 +1,27 @@
+use dioxus::prelude::*;
+use dioxus_router::prelude::*;
+use dioxus_logger::tracing;
 use ml_runner::app;
 
-#[tokio::main]
-async fn main() {
+fn main() {
+    #[cfg(feature = "server")]
+    tokio::runtime::Runtime::new()
+        .unwrap()
+        .block_on(launch_server());
+    #[cfg(not(feature = "server"))]
     dioxus::launch(app);
+}
+
+#[cfg(feature = "server")]
+async fn launch_server() {
+    dioxus::logger::initialize_default();
+
+    let socket_addr = dioxus_cli_config::fullstack_address_or_localhost();
+
+    let router = axum::Router::new()
+        .serve_dioxus_application(ServeConfigBuilder::new(), app)
+        .into_make_service();
+
+    let listener = tokio::net::TcpListener::bind(socket_addr).await.unwrap();
+    axum::serve(listener, router).await.unwrap();
 }


### PR DESCRIPTION
## Summary
- remove server startup from `bin/server.rs` so it strictly executes pipeline commands
- document how to run Dioxus with `dx serve` and trigger training from a separate CLI session

## Testing
- `cargo check` *(fails: command not found: cargo)*


------
https://chatgpt.com/codex/tasks/task_e_68af0054ff188330b5e982fefb0cde86